### PR TITLE
DOC-3310 Update public doc links in public dev repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Curl and libcurl now supports AWSv4 signatures which allow Outscale users to use
 
 Not every language has an SDK for Outscale API but you can use libcurl to ease your journey thanks to [FFI](https://en.wikipedia.org/wiki/Foreign_function_interface).
 
-This repository shows how to use libcurl with [Outscale's API](https://docs.outscale.com/api) in different programming languages.
+This repository shows how to use libcurl with [Outscale's API](https://docs.outscale.com/api.html) in different programming languages.
 
 # Running examples
 


### PR DESCRIPTION
added .html to https://docs.outscale.com/api